### PR TITLE
Added missing ` in the OP Stack Getting Started

### DIFF
--- a/src/docs/build/getting-started.md
+++ b/src/docs/build/getting-started.md
@@ -43,7 +43,7 @@ This tutorial was checked on:
 | Ubuntu   | 20.04 LTS  | |
 | git, curl, jq, and make | OS default | `sudo apt install -y git curl make jq` |
 | Go       | 1.20       | `sudo apt update` <br> `wget https://go.dev/dl/go1.20.linux-amd64.tar.gz` <br> `tar xvzf go1.20.linux-amd64.tar.gz` <br> `sudo cp go/bin/go /usr/bin/go` <br> `sudo mv go /usr/lib` <br> `echo export GOROOT=/usr/lib/go >> ~/.bashrc`
-| Node     | 16.19.0    | `curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -` <br> `sudo apt-get install -y nodejs npm`
+| Node     | 16.19.0    | `curl -fsSL https://deb.nodesource.com/setup_16.x \| sudo -E bash -` <br> `sudo apt-get install -y nodejs npm`
 | pnpm     | 8.5.6      | `sudo npm install -g pnpm`
 | Foundry  | 0.2.0      | `yarn install:foundry`
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Added a missing ` character that prevents correct rendering on markdown.

**Tests**

No tests added since this is does not make any changes in behaviour or logic. This is a documentation only change.

**Additional context**

You can see how the current markdown fails to render on this page:
https://github.com/ethereum-optimism/stack-docs/blob/main/src/docs/build/getting-started.md
See the "`curl -fsSL https://deb.nodesource.com/setup_16.x" not being rendered correctly and this can lead to confusion.

**Metadata**

No issue created since this is a small fix. Lmk if you need me to create one.

Thanks to putting this togheter. I'll be doing guides about the OP stack on youtube and blog posts. This is very well explained. If I find more issues I'll report back.
