### PR TITLE
fixed bug while attempting to execute script for running op-node

### DIFF
--- a/src/docs/build/getting-started.md
+++ b/src/docs/build/getting-started.md
@@ -420,7 +420,6 @@ cd ~/optimism/op-node
 ./bin/op-node \
 	--l2=http://localhost:8551 \
 	--l2.jwt-secret=./jwt.txt \    
-	--sequencer.enabled \
 	--sequencer.l1-confs=3 \
 	--verifier.l1-confs=3 \
 	--rollup.config=./rollup.json \


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Removed `--sequencer.enabled \` flag from the op-node script, which now allows for it to run succesfully.

**Tests**

With `--sequencer.enabled \`
![Screenshot from 2023-08-01 00-25-14](https://github.com/ethereum-optimism/stack-docs/assets/32080359/c85d5993-abdf-4a51-a7cf-85ea094ff6a0)

**Fixes**

Without `--sequencer.enabled \`
![Screenshot from 2023-08-01 00-36-26](https://github.com/ethereum-optimism/stack-docs/assets/32080359/ee7ccf38-3b53-46c4-ba28-17b1dba77a38)
