### PR TITLE
Fix typo in forced-withdrawal

### DIFF
--- a/src/docs/security/forced-withdrawal.md
+++ b/src/docs/security/forced-withdrawal.md
@@ -155,7 +155,7 @@ The easiest way to withdraw ETH is to send it to the bridge, or the cross domain
    ```
 
 1. Wait for the message status for the withdrawal to become `READY_TO_PROVE`.
-   By default the state root is written every four minutes, so you're likely to need to need to wait.
+   By default, the state root is written every four minutes, so you're likely to need to wait.
 
    ```js
    await crossChainMessenger.waitForMessageStatus(withdrawalHash, 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Fix typo in forced-withdrawal, remove the duplicated words

**Tests**

Document change, no code update

**Additional context**

No

**Metadata**
No