### PR TITLE
Update data-avail.md: Non-EVM DA (PoDA)

### DIFF
--- a/src/docs/build/data-avail.md
+++ b/src/docs/build/data-avail.md
@@ -40,7 +40,11 @@ An example of an EVM-Ordered Alternative DA module can be found within [this mod
 
 ### Non-EVM DA
 
-A non-EVM DA module uses a chain not based on the EVM to manage both the ordering and storage of raw input data. Such a modification would require relatively significant modifications to the [derivation portion](https://github.com/ethereum-optimism/optimism/tree/129032f15b76b0d2a940443a39433de931a97a44/op-node/rollup/derive) of the `op-node`. No such fully-independent DA modules have been developed yet — be the first!
+A non-EVM DA module uses a chain not based on the EVM to manage both the ordering and storage of raw input data. Such solutions require relatively significant modifications to the [derivation portion](https://github.com/ethereum-optimism/optimism/tree/129032f15b76b0d2a940443a39433de931a97a44/op-node/rollup/derive) of the `op-node`.
+
+The first fully-independent DA module can be found within [the Rollux fork of the OP Stack](https://github.com/sys-labs/rollux/commit/25a4c9410ddae31ff7195f67495491f71e684e03) that uses [PoDA Protocol (Proof of Data Availability)](https://docs.rollux.com/docs/sys/PoDA/). PoDA is a layer 1 DA solution served by the Syscoin blockchain.
+
+The Rollux implementation of PoDA also provides [a path for serving PoDA to fractal layers (L3 and beyond) through layer 2](https://github.com/sys-labs/rollux/commit/6de6849f60f20f1e0b5ca314daa543344010003e).
 
 ### Multiple DA
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

Please read!  Your attention is appreciated.

The first Non-EVM DA within the OP Stack Community now exists;  a protocol called Proof of Data Availability.  It is used by the Rollux fork of Optimism.  PoDA is L1 and has been mainnet for about eight months while Rollux has been mainnet since June 28th.

You can find out about PoDA's design here:
https://docs.rollux.com/docs/sys/PoDA/#optimistic-rollup-with-poda-proof-of-data-availability

PoDA is available for anyone to use. Being PoW at its base with a hybrid finality makes it interesting to include in a Multi-DA environment, as it would give a rollup architectural resilience in its DA, in a world where the vast majority of DA solutions are Proof-of-Stake.  PoDA also does not use sharding, another differentiation from EIP-4844.  State proof is settled on a UTXO-based chain that is merge mined with Bitcoin plus finality, and raw data is archived offchain in its entirety by each participating full node (open network), bringing a lot of censorship resistance.

To see the DA difference in the code, a delta between the OP and Rollux approach to DA is visible here: https://github.com/sys-labs/rollux/commit/25a4c9410ddae31ff7195f67495491f71e684e03

ALSO, since OP is pursuing modularization of DA in Superchain, it's worth noting that Team Rollux and Syscoin Foundation have some interest in contributing there.

All the best!


**Tests**

**Additional context**

**Metadata**

- Fixes #[Link to Issue]
