### PR TITLE
Fix the broken link in operation page and adding sequencer mode note

### DIFF
--- a/src/docs/build/operations.md
+++ b/src/docs/build/operations.md
@@ -88,4 +88,4 @@ You should *not* add an `op-bathcer`, there should be only one.
    If you already have peer to peer synchronization, add the new node to the `--p2p.static` list so it can synchronize.
 
 1. Start `op-geth` (using the same command line you used on the initial node)
-1. Start `op-node` (using the same command line you used on the initial node but with sequencer mode disabled)
+1. Start `op-node` (using the same command line you used on the initial node but with sequencer mode disabled by removing `--sequencer.enabled` and `--sequencer.l1-confs` flags)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

1. Fix the broken link in https://stack.optimism.io/docs/build/operations/#starting-your-rollup
2. Add a note that sequencer mode must be disabled on the second node (Until decentralized sequencer is implemented)
