### PR TITLE
Optimism repo must be cloned with recurse submodules

### DIFF
--- a/src/docs/build/getting-started.md
+++ b/src/docs/build/getting-started.md
@@ -57,7 +57,7 @@ We’re going to be spinning up an EVM Rollup from the OP Stack source code.  Yo
 
     ```bash
     cd ~
-    git clone https://github.com/ethereum-optimism/optimism.git
+    git clone https://github.com/ethereum-optimism/optimism.git --recurse-submodules
     ```
 
 1. Enter the Optimism Monorepo.

--- a/src/docs/build/getting-started.md
+++ b/src/docs/build/getting-started.md
@@ -57,7 +57,7 @@ We’re going to be spinning up an EVM Rollup from the OP Stack source code.  Yo
 
     ```bash
     cd ~
-    git clone https://github.com/ethereum-optimism/optimism.git --recurse-submodules
+    git clone --recurse-submodules https://github.com/ethereum-optimism/optimism.git
     ```
 
 1. Enter the Optimism Monorepo.


### PR DESCRIPTION
https://github.com/ethereum-optimism/optimism/issues/7558

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Add `--recurse-submodules` to optimism repo cloning step

**Additional context**

Submodules are primarily used at https://github.com/ethereum-optimism/optimism/tree/develop/packages/contracts-bedrock/lib

**Metadata**

- Fixes https://github.com/ethereum-optimism/optimism/issues/7558
