### PR TITLE
Update getting-started.md

### DIFF
--- a/src/docs/build/getting-started.md
+++ b/src/docs/build/getting-started.md
@@ -45,7 +45,7 @@ This tutorial was checked on:
 | Go       | 1.20       | `sudo apt update` <br> `wget https://go.dev/dl/go1.20.linux-amd64.tar.gz` <br> `tar xvzf go1.20.linux-amd64.tar.gz` <br> `sudo cp go/bin/go /usr/bin/go` <br> `sudo mv go /usr/lib` <br> `echo export GOROOT=/usr/lib/go >> ~/.bashrc`
 | Node     | 16.19.0    | `curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -` <br> `sudo apt-get install -y nodejs npm`
 | pnpm     | 8.5.6      | `sudo npm install -g pnpm`
-| Foundry  | 0.2.0      | `yarn install:foundry`
+| Foundry  | 0.2.0      | `curl -L https://foundry.paradigm.xyz | bash` <br> `. ~/.bashrc` <br> `foundryup`
 
 ### Configuring direnv
 


### PR DESCRIPTION
The original statement "yarn install: foundry" has the following issues:

- There was no prior mention of installing Yarn.
- This command appears to be only available within the "optimism" directory, and we haven't yet cloned the "optimism" repository.
- Even if you successfully download "foundry" using this method, it will not be immediately usable.


