### PR TITLE
Update getting-started.md (add make submodules)

### DIFF
--- a/src/docs/build/getting-started.md
+++ b/src/docs/build/getting-started.md
@@ -166,6 +166,12 @@ make op-node op-batcher op-proposer
 pnpm build
 ```
 
+#### 6. Init and Pull submodules inside of the Optimism Monorepo
+
+```bash
+make submodules
+```
+
 ### Build `op-geth`
 
 #### 1. Clone op-geth


### PR DESCRIPTION
- add `make submodules` logic Submodules is required when we deploy contracts to get dependency of contracts

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

This PR add `make submodules` logic.
Submodules is required when we deploy contracts to get dependency of contracts

**Tests**

This is just to add `make submodules`. When there is no logic I've got below error. But It fixed after execution the command
```
Failed to resolve file: "ethereum-optimism/optimism/packages/contracts-bedrock/lib/forge-std/src/Vm.sol": No such file or directory (os error 2).
 Check configured remappings..
    --> "ethereum-optimism/optimism/packages/contracts-bedrock/scripts/ChainAssertions.sol"
        "forge-std/Vm.sol"
```
