### PR TITLE
Change application port and command in Blockscout launch instruction

### DIFF
--- a/src/docs/build/explorer.md
+++ b/src/docs/build/explorer.md
@@ -52,12 +52,12 @@ Download and install [Docker engine](https://docs.docker.com/engine/install/#ser
 1. Start Blockscout
 
    ```sh
-   docker compose -f docker-compose-no-build-geth.yml up
+   DOCKER_REPO=blockscout-optimism docker compose -f geth.yml up
    ```
 
 ## Usage
 
-After the docker containers start, browse to http:// < *computer running Blockscout* > :4000 to view the user interface. 
+After the docker containers start, browse to http:// < *computer running Blockscout* > :80 to view the user interface. 
 
 You can also use the [API](https://docs.blockscout.com/for-users/api)
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Change explorer (Blockscout) running instructions:
- change explorer port 4000 -> 80
- launching command is changed: specific to OP-stack docker image is used and the name of config.yml is changed.


**Additional context**

This should be merged after https://github.com/blockscout/blockscout/pull/8956 merged.

