### PR TITLE
added pnpm install command to build optimism monorepo

### DIFF
--- a/src/docs/build/getting-started.md
+++ b/src/docs/build/getting-started.md
@@ -163,6 +163,7 @@ pnpm install
 
 ```bash
 make op-node op-batcher op-proposer
+pnpm install
 pnpm build
 ```
 


### PR DESCRIPTION
Added pnpm install command for building the optimism repo

<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**
When I was trying to build optimism monorepo using `pnpm build` command right after this command `make op-node op-batcher op-proposer` . First it was confusing after then I found out I have to use `pnpm install` command first after then we have to use `pnpm build` command.
Ref: https://stack.optimism.io/docs/build/getting-started/#build-the-optimism-monorepo

**Tests**

Since it's documentation changes test cases are not needed.

**Additional context**

Adding `pnpm install` command before `pnpm build` would make installation easier otherwise it'll throw `NX not found error` also people confuse with `yarn/npm install`. So this would help beginners to understand these commands properly.
